### PR TITLE
Add target to inform user on "make project" when missing required dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
  - sudo apt-get install -qq libboost-chrono-dev || /bin/true
  - sudo apt-get install -qq libboost-date-time-dev || /bin/true
  - sudo apt-get install -qq libboost-filesystem-dev || /bin/true
- - sudo apt-get install -qq libboost-iostreams-dev || /bin/true
  - sudo apt-get install -qq libboost-program-options-dev || /bin/true
  - sudo apt-get install -qq libboost-python-dev || /bin/true
  - sudo apt-get install -qq libboost-regex-dev || /bin/true

--- a/CMake/Makefile.in
+++ b/CMake/Makefile.in
@@ -15,7 +15,7 @@ configure:
 test:
 	@$(MAKE) --no-print-directory -C @BUILDYARD@/$(BUILD)/@name@ tests
 
-include @BUILDYARD@/$(BUILD)/projects.make
+-include @BUILDYARD@/$(BUILD)/projects.make
 
 %:
 	@$(MAKE) --no-print-directory -C @BUILDYARD@/${BUILD}/@name@ $@

--- a/config/ITK.cmake
+++ b/config/ITK.cmake
@@ -1,3 +1,2 @@
 set(ITK_PACKAGE_VERSION 4.0)
-set(ITK_DEB_NAME libinsighttoolkit4-dev)
 set(ITK_CMAKE_INCLUDE "SYSTEM")


### PR DESCRIPTION
{code}
[skywriter ~/Buildyard master]> make NeuMaya
Can't build NeuMaya: missing Maya
make[4]: fail: Command not found
make[4]: *** [CMakeFiles/NeuMaya-missing] Error 127
make[3]: *** [CMakeFiles/NeuMaya-missing.dir/all] Error 2
make[2]: *** [CMakeFiles/NeuMaya.dir/rule] Error 2
make[1]: *** [NeuMaya] Error 2
make: *** [NeuMaya] Error 2
[skywriter ~/Buildyard master]> 
{code}